### PR TITLE
fixes for openapi v3 specification

### DIFF
--- a/dtaservice/dtaservice.swagger.json
+++ b/dtaservice/dtaservice.swagger.json
@@ -25,17 +25,8 @@
         "description": "The response **must** be a valid [JSON Schema](http://json-schema.org/draft-07/schema#).",
         "responses": {
           "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Invalid Schema",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OptionsErrorResponse"
-                }
-              }
-            }
+            "description": "OK",
+            "type": "object"
           },
           "504": {
             "description": "Gateway Timeout",
@@ -199,6 +190,16 @@
               }
             }
           },
+          "400": {
+            "description": "Validation Error (from called service)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptionsErrorResponse"
+                }
+              }
+            }
+          },
           "504": {
             "description": "Gateway Timeout",
             "content": {
@@ -326,9 +327,6 @@
           },
           "options": {
             "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
             "description": "Service options.",
             "example": {
               "offset": 5,
@@ -338,9 +336,13 @@
         }
       },
       "PipeService": {
+       "required": [
+          "name"
+        ],
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "example": "DE.TU-BERLIN.QDS.COUNT"
           },
           "options": {
             "type": "object"
@@ -368,6 +370,7 @@
           },
           "file_name": {
             "type": "string",
+            "example": "simpletext.txt",
             "description": "The filename of the document."
           }
         }
@@ -390,17 +393,24 @@
             "description": "Standard output from the specified service.",
             "items": {
               "type": "string"
-            }
+            },
+            "example": [
+              "transforming document <simpletext.txt> ..."
+            ],
           },
           "error": {
             "type": "array",
             "description": "Standard error from the specified service.",
             "items": {
               "type": "string"
-            }
+            },
+            "example": [
+              "Unknown Exception"
+            ],
           },
           "last_transformer": {
             "type": "string",
+            "example": "DE.TU-BERLIN.QDS.COUNT",
             "description": "Name of the last service which transformed the document."
           }
         }

--- a/dtaservice/dtaservice.swagger.json
+++ b/dtaservice/dtaservice.swagger.json
@@ -22,7 +22,7 @@
           "service"
         ],
         "summary": "Retrieves available options of the service.",
-        "description": "The response **must** be a valid [JSON Schema](http://json-schema.org/draft-07/schema#).",
+        "description": "The response **has to** be a valid [JSON Schema](http://json-schema.org/draft-07/schema#).",
         "responses": {
           "200": {
             "description": "OK",
@@ -169,6 +169,7 @@
           "document"
         ],
         "summary": "Executes a given sequence of transforms on a plain document.",
+        "description": "The services inside the list (`[0, 1, ..., n]`) **has to** be handled in ascending order from the first (`0`) to the last (`n`) element.",
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
Co-authored-by: B4rtware <34386047+B4rtware@users.noreply.github.com>

# Changes
- Delete Invalid Schema response (400) from /options
- Delete additionalProperties from TransformDocumentRequest options type
+ Make property "name" for PipeService required
+ Add Invalid Schema response (400) from /transform-pipe
+ Add more examples